### PR TITLE
Auto-Comment continue on next line

### DIFF
--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -12,3 +12,7 @@ setl lispwords+=match,match*,match/values,define/match,match-lambda,match-lambda
 setl lispwords+=match-let,match-let*,match-let-values,match-let*-values
 setl lispwords+=match-letrec,match-define,match-define-values
 setl lisp
+
+" Enable auto begin new comment line when continuing from an old comment line
+set comments+=:;
+set fo+=r


### PR DESCRIPTION
I've been using this fantastic plugin for a while, but there's bunch of features I sorely missed.
Automatic comment continuation was one of them, if this was skipped due to an oversight and not because of a conscious decision, then here's a pull that adds this feature.

Tested with:
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled May 12 2014 22:27:13)
MacOS X (unix) version
Included patches: 1-273
Compiled by Homebrew
