### PR TITLE
Fix syntax highlighting for #o and #b literals

### DIFF
--- a/syntax/racket.vim
+++ b/syntax/racket.vim
@@ -475,8 +475,8 @@ syn cluster racketQuotedOrNormal  add=racketString
 " #x, #i, or #e, is an error
 syn match racketNumberError         "\<#[xdobie]\k*"
 
-syn match racketContainedNumberError   "\<#o\k*[^-+0-7delfinas#./@]"
-syn match racketContainedNumberError   "\<#b\k*[^-+01delfinas#./@]"
+syn match racketContainedNumberError   "\<#o\k*[^-+0-7delfinas#./@]\>"
+syn match racketContainedNumberError   "\<#b\k*[^-+01delfinas#./@]\>"
 syn match racketContainedNumberError   "\<#[ei]#[ei]"
 syn match racketContainedNumberError   "\<#[xdob]#[xdob]"
 


### PR DESCRIPTION
Octal and binary literals were being highlighted as errors unless
followed by a newline (so for example, when followed by a space or a
')'). This commit introduces the intended behavior by adding the "end of
word" marker to the end of the appropriate regexes.

My testing indicates that this change yields correct behavior, but I do
not fully grok the surrounding regexes, so no guarantees I'm afraid.