### PR TITLE
Remove autoload/racket.vim as it is never used.

### DIFF
--- a/autoload/racket.vim
+++ b/autoload/racket.vim
@@ -1,3 +1,0 @@
-if !exists("g:raco_command")
-  let g:raco_command = system("which raco")
-endif


### PR DESCRIPTION
I think the original contributor wanted to use it for `makeprg` but I don't think that it is even necessary.