### PR TITLE
Use `setfiletype` in ftdetect to avoid loading twice.

### DIFF
--- a/ftdetect/racket.vim
+++ b/ftdetect/racket.vim
@@ -1,1 +1,1 @@
-au BufRead,BufNewFile *.rkt,*.rktl  set filetype=racket
+au BufRead,BufNewFile *.rkt,*.rktl setf racket


### PR DESCRIPTION
This is the "correct" way of doing it and is what the [official vim runtime files do](https://github.com/vim/vim/blob/2ba4238818ca5ea52334de3037ef3729584cebf5/runtime/filetype.vim#L1496)