### PR TITLE
Tries to detect filetype from #lang line

### DIFF
--- a/ftdetect/racket.vim
+++ b/ftdetect/racket.vim
@@ -1,1 +1,18 @@
-au BufRead,BufNewFile *.rkt,*.rktl set filetype=racket
+" 
+let g:racket_hash_lang_regexp = '^#lang\s\+\([^][)(}{[:space:]]\+\)'
+
+" Tries to detect filetype from #lang line; defaults to ft=racket.
+function RacketDetectHashLang()
+  let old_ft = &filetype
+
+  let matches = matchlist(getline(1), g:racket_hash_lang_regexp)
+  if ! empty(matches)
+    let &l:filetype = matches[1]
+  endif
+
+  if &filetype == old_ft
+    set filetype=racket
+  endif
+endfunction
+
+au BufRead,BufNewFile *.rkt,*.rktl call RacketDetectHashLang()


### PR DESCRIPTION
This PR modifies `ftdetect/racket.vim` to attempt to detect and set the filetype from the `#lang` line. If either detecting or setting the filetype fails then it sets the filetype to `racket` by default.