### PR TITLE
Add include guard and b:undo_ftplugin rules

### DIFF
--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -60,3 +60,11 @@ vnoremap <buffer> K :call <SID>Racket_visual_doc()<cr>
 
 "setl commentstring=;;%s
 setl commentstring=#\|\ %s\ \|#
+
+" Undo our settings when the filetype changes away from Racket
+" (this should be amended if settings/mappings are added above!)
+let b:undo_ftplugin =
+      \  "setl iskeyword< lispwords< lisp< comments< formatoptions<"
+      \. "| setl makeprg< commentstring<"
+      \. "| nunmap <buffer> K"
+      \. "| vunmap <buffer> K"

--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -2,6 +2,11 @@
 " Maintainer:   Will Langstroth <will@langstroth.com>
 " URL:          http://github.com/wlangstroth/vim-racket
 
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
 setl iskeyword+=#,%,^
 setl lispwords+=module,module*,module+,parameterize,let-values,let*-values,letrec-values,local
 setl lispwords+=define-values,opt-lambda,case-lambda,syntax-rules,with-syntax,syntax-case,syntax-parse


### PR DESCRIPTION
This PR adds a few changes to make the plugin a better Vim citizen. It prevents the ftplugin from loading twice in a buffer, and sets `b:undo_ftplugin` rules so that our settings will be cleared if the user sets a new filetype in the buffer.