### PR TITLE
Fix beginning new lines with multiple semicolons

### DIFF
--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -30,7 +30,7 @@ setl lispwords+=match-letrec,match-define,match-define-values
 setl lisp
 
 " Enable auto begin new comment line when continuing from an old comment line
-setl comments+=:;
+setl comments+=:;;;;,:;;;,:;;,:;
 setl formatoptions+=r
 
 setl makeprg=raco\ make\ --\ %


### PR DESCRIPTION
works up to 4, the same amount as vim's default scheme setting.

Behavior before:

```
;;; blah<return>
;<cursor>
```

Behavior now:

```
;;; blah<return>
;;; <cursor>
```