### PR TITLE
Syntax coloring for syntax-parse forms.

### DIFF
--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -9,7 +9,8 @@ let b:did_ftplugin = 1
 
 setl iskeyword+=#,%,^
 setl lispwords+=module,module*,module+,parameterize,let-values,let*-values,letrec-values,local
-setl lispwords+=define-values,opt-lambda,case-lambda,syntax-rules,with-syntax,syntax-case,syntax-parse
+setl lispwords+=define-values,opt-lambda,case-lambda,syntax-rules,with-syntax,syntax-case
+setl lispwords+=syntax-parse,syntax-parser,define/syntax-parse,define-syntax-class,define-splicing-syntax-class,define-simple-macro,define-syntax-parser,define-literal-set,define-conventions
 setl lispwords+=define-signature,unit,unit/sig,compund-unit/sig,define-values/invoke-unit/sig
 setl lispwords+=define-opt/c,define-syntax-rule
 setl lispwords+=struct

--- a/syntax/racket.vim
+++ b/syntax/racket.vim
@@ -467,6 +467,8 @@ syn keyword racketFunc path-element? path-only simple-form-path some-simple-path
 syn keyword racketFunc current-seconds current-inexact-milliseconds
 syn keyword racketFunc seconds->date current-milliseconds
 
+" syntax/parse: https://docs.racket-lang.org/syntax/stxparse.html
+syn keyword racketSyntax syntax-parse syntax-parser define/syntax-parse define-syntax-class define-splicing-syntax-class define-simple-macro define-syntax-parser define-literal-set define-conventions
 
 syn match racketDelimiter !\<\.\>!
 


### PR DESCRIPTION
Do you have a policy on which identifiers to include here?
`syntax-parse` and friends aren’t in the manual, but I believe they’re
the preferred way to write macros at this point, so maybe racket.vim
should support them.