### PR TITLE
ftdetect: make #lang detection more robust

### DIFF
--- a/ftdetect/racket.vim
+++ b/ftdetect/racket.vim
@@ -1,17 +1,27 @@
-" 
 let g:racket_hash_lang_regexp = '^#lang\s\+\([^][)(}{[:space:]]\+\)'
+let g:racket_hash_lang_dict = get(g:, 'racket_hash_lang_dict',
+      \ {
+      \   'racket/base': 'racket',
+      \   'typed/racket': 'racket',
+      \   'scribble/base': 'scribble',
+      \   'scribble/manual': 'scribble',
+      \ })
 
 " Tries to detect filetype from #lang line; defaults to ft=racket.
 function! RacketDetectHashLang()
-  let old_ft = &filetype
-
+  let redo_autocommands = !empty(&filetype)
   let matches = matchlist(getline(1), g:racket_hash_lang_regexp)
   if ! empty(matches)
-    let &l:filetype = matches[1]
-  endif
-
-  if &filetype == old_ft
+    execute 'set filetype='.get(g:racket_hash_lang_dict, matches[1], substitute(matches[1], '[/\*?[|<>]', '', 'g'))
+  else
     set filetype=racket
+  endif
+  if redo_autocommands
+    if g:syntax_on
+      execute 'doautocmd syntaxset FileType' &filetype
+    endif
+    execute 'doautocmd filetypeplugin FileType' &filetype
+    execute 'doautocmd filetypeindent FileType' &filetype
   endif
 endfunction
 

--- a/ftdetect/racket.vim
+++ b/ftdetect/racket.vim
@@ -3,6 +3,7 @@ let g:racket_hash_lang_dict = get(g:, 'racket_hash_lang_dict',
       \ {
       \   'racket/base': 'racket',
       \   'typed/racket': 'racket',
+      \   'typed/racket/base': 'racket',
       \   'br': 'racket',
       \   'br/quicklang': 'racket',
       \   'scribble/base': 'scribble',

--- a/ftdetect/racket.vim
+++ b/ftdetect/racket.vim
@@ -9,19 +9,11 @@ let g:racket_hash_lang_dict = get(g:, 'racket_hash_lang_dict',
 
 " Tries to detect filetype from #lang line; defaults to ft=racket.
 function! RacketDetectHashLang()
-  let redo_autocommands = !empty(&filetype)
   let matches = matchlist(getline(1), g:racket_hash_lang_regexp)
   if ! empty(matches)
     execute 'set filetype='.get(g:racket_hash_lang_dict, matches[1], substitute(matches[1], '[/\*?[|<>]', '', 'g'))
   else
     set filetype=racket
-  endif
-  if redo_autocommands
-    if g:syntax_on
-      execute 'doautocmd syntaxset FileType' &filetype
-    endif
-    execute 'doautocmd filetypeplugin FileType' &filetype
-    execute 'doautocmd filetypeindent FileType' &filetype
   endif
 endfunction
 

--- a/ftdetect/racket.vim
+++ b/ftdetect/racket.vim
@@ -3,6 +3,8 @@ let g:racket_hash_lang_dict = get(g:, 'racket_hash_lang_dict',
       \ {
       \   'racket/base': 'racket',
       \   'typed/racket': 'racket',
+      \   'br': 'racket',
+      \   'br/quicklang': 'racket',
       \   'scribble/base': 'scribble',
       \   'scribble/manual': 'scribble',
       \ })


### PR DESCRIPTION
- The dict is used to map "bad" filetypes to work-able filetypes
  ('filetype' cannot contain certain characters). See also the
  substitute function invocation.

- old_ft is not necessary; but, we do need to redo the syntax (if syntax
  is on), the ftplugin, and the filetype-indent autocommands to make
  sure the syntax, &c., works out.

  We can safely do the ftplugin/indent commands because they are "off"
  the groups are empty (a silent[!] might be necessary to avoid "no
  matching autocommands" or something similar).

- It is possible we can go back to "let &l:filetype" instead of "execute
  'set filetypes='", but this is working.