### PR TITLE
ftdetect: Support #lang at-exp chains

### DIFF
--- a/ftdetect/racket.vim
+++ b/ftdetect/racket.vim
@@ -1,4 +1,4 @@
-let g:racket_hash_lang_regexp = '^#lang\s\+\([^][)(}{[:space:]]\+\)'
+let g:racket_hash_lang_regexp = '^#lang\s\+\%\(\<at-exp\>\s\+\)\?\([^][)(}{[:space:]]\+\)'
 let g:racket_hash_lang_dict = get(g:, 'racket_hash_lang_dict',
       \ {
       \   'racket/base': 'racket',

--- a/test/at-exp.rkt
+++ b/test/at-exp.rkt
@@ -1,0 +1,9 @@
+#lang at-exp racket
+
+(define (bar)
+  "BAR")
+
+(define (foo)
+  (displayln @~a{Foo is a @(bar)}))
+
+(foo)


### PR DESCRIPTION
Modifies the regular expression to ignore `at-exp` when present in the #lang statement, and use the next language in the chain.

See documentation for #lang at-exp at https://docs.racket-lang.org/scribble/reader-internals.html#%28part._at-exp-lang%29