### PR TITLE
Add racket/gui to ftdetect languages dict

### DIFF
--- a/ftdetect/racket.vim
+++ b/ftdetect/racket.vim
@@ -2,6 +2,7 @@ let g:racket_hash_lang_regexp = '^#lang\s\+\([^][)(}{[:space:]]\+\)'
 let g:racket_hash_lang_dict = get(g:, 'racket_hash_lang_dict',
       \ {
       \   'racket/base': 'racket',
+      \   'racket/gui': 'racket',
       \   'typed/racket': 'racket',
       \   'typed/racket/base': 'racket',
       \   'br': 'racket',

--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -15,7 +15,7 @@ setl lispwords+=define-opt/c,define-syntax-rule
 setl lispwords+=struct
 
 " Racket OOP
-setl lispwords+=class,define/public,define/private
+setl lispwords+=class,define/public,define/private,define/override
 
 " kanren
 setl lispwords+=fresh,run,run*,project,conde,condu


### PR DESCRIPTION
racket/gui is similar enough to standard racket that it's useful to use its syntax highlighting