### PR TITLE
Suppress unmap errors at undo_ftplugin

### DIFF
--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -77,6 +77,6 @@ endif
 let b:undo_ftplugin =
       \  "setl iskeyword< lispwords< lisp< comments< formatoptions<"
       \. "| setl makeprg< commentstring<"
-      \. "| nunmap <buffer> K"
-      \. "| vunmap <buffer> K"
+      \. "| silent! nunmap <buffer> K"
+      \. "| silent! vunmap <buffer> K"
       \. "| unlet! b:browsefilter"

--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -77,6 +77,6 @@ endif
 let b:undo_ftplugin =
       \  "setl iskeyword< lispwords< lisp< comments< formatoptions<"
       \. "| setl makeprg< commentstring<"
-      \. "| silent! nunmap <buffer> K"
-      \. "| silent! vunmap <buffer> K"
+      \. "| silent! execute 'nunmap <buffer> K'"
+      \. "| silent! execute 'vunmap <buffer> K'"
       \. "| unlet! b:browsefilter"


### PR DESCRIPTION
This pull request suppresses errors relate to unmappings at unloading of this plugin.

The `nmap`/`vmap` both are currently set only if those mappings aren't set yet by others (with chesk of `maparg(...)` at [L44](https://github.com/wlangstroth/vim-racket/blob/3948cc5f100b1d1f7d7e4c302e99527c1858e229/ftplugin/racket.vim#L44-L46) and [L63](https://github.com/wlangstroth/vim-racket/blob/3948cc5f100b1d1f7d7e4c302e99527c1858e229/ftplugin/racket.vim#L63-L65)). So, if these buffer local mappings are not set (I had another mapping for `K`), then errors like below occur when `b:undo_ftplugin` is evaluated, since they don't exist.

```txt
Error detected while processing BufRead Autocommands for "*.rkt"..function <SNR>55_RacketDetectHashLang[3]..FileType Autocommands 
for "*"..function <SNR>20_LoadFTPlugin:
line    3:
E31: No such mapping
```

I suppose these errors would be harmless (because buffer local mappings does not exist), but a bit annoying, so I've simply added `silent!` at here 😄 